### PR TITLE
Unique files, cleanup images after delete, custom admin list and python 3 support

### DIFF
--- a/django_images/admin.py
+++ b/django_images/admin.py
@@ -4,6 +4,7 @@ from .models import Image
 
 
 def size_display_factory(size):
+    """Create a function to use an a model field display in the admin list"""
     def getter(model):
         infos = getattr(model, size)
         html = '<a href="%s">%s</a>'
@@ -20,6 +21,7 @@ def size_display_factory(size):
 
 
 class ImageAdmin(admin.ModelAdmin):
+    """Custom admin for Image model"""
 
     list_display = ['preview', 'name', 'xs', 'sm', 'md', 'lg', 'og']
 
@@ -30,6 +32,7 @@ class ImageAdmin(admin.ModelAdmin):
         super(ImageAdmin, self).__init__(*args, **kwargs)
 
     def preview(self, model):
+        """Display the image in the smallest size"""
         html = '<img src="%s" alt="%s"/>' % (
             model.xs['url'],
             model.name

--- a/django_images/admin.py
+++ b/django_images/admin.py
@@ -1,3 +1,40 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Image
+
+
+def size_display_factory(size):
+    def getter(model):
+        infos = getattr(model, size)
+        html = '<a href="%s">%s</a>'
+        label = '%sx%s' % (infos['width'], infos['height'])
+        html = html % (
+            model.url(size),
+            label
+        )
+        return html
+    getter.__name__ = size
+    getter.allow_tags = True
+    getter.short_description = size
+    return getter
+
+
+class ImageAdmin(admin.ModelAdmin):
+
+    list_display = ['preview', 'name', 'xs', 'sm', 'md', 'lg', 'og']
+
+    def __init__(self, *args, **kwargs):
+        for size in ['xs', 'sm', 'md', 'lg', 'og']:
+            setattr(self, size, size_display_factory(size))
+
+        super(ImageAdmin, self).__init__(*args, **kwargs)
+
+    def preview(self, model):
+        html = '<img src="%s" alt="%s"/>' % (
+            model.xs['url'],
+            model.name
+        )
+        return html
+    preview.allow_tags = True
+
+admin.register(Image)(ImageAdmin)

--- a/django_images/forms.py
+++ b/django_images/forms.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import sys
+
 from PIL import Image
 from django import forms
 
@@ -9,12 +11,19 @@ from .models import IMAGE_CHOICES
 from .settings import IMAGE_FORMATS
 
 
+if sys.version_info > (3, 0):
+    print(sys.version_info)
+    PY3 = True
+else:
+    PY3 = False
+
+
 def validate(image, ptype):
     # compute max constraint size with method
     formats = IMAGE_FORMATS[ptype]
-    maximum = formats['sizes'].values()[0]['size']
-    method = formats['sizes'].values()[0]['method']
-    for value in formats['sizes'].values()[1:]:
+    maximum = list(formats['sizes'].values())[0]['size']
+    method = list(formats['sizes'].values())[0]['method']
+    for value in list(formats['sizes'].values())[1:]:
         size = max(maximum, value['size'])
         if size != maximum:
             method = value['method']
@@ -22,26 +31,34 @@ def validate(image, ptype):
     method = 'resize_' + method
     method = getattr(resizeimage, method)
 
-    # mock close method so that PIL doesn't really close image
-    close_method = image.close
-    image.close = lambda *args, **kwargs: None
+    # XXX: monkey patch close method
+    # so that PIL doesn't really close the file
+    # XXX: with Python 2 we can do this on `image`
+    # but because of the new behavior of str/bytes
+    # in python 3 we use the raw fd
+    if PY3:
+        fd = image.file.buffer.raw
+    else:
+        fd = image
+    close_method = fd.close
+    fd.close = lambda *args, **kwargs: None
     try:
         # do validation against the max constraint
-        with Image.open(image) as pil_image:
+        with Image.open(fd) as pil_image:
             method.validate(pil_image, maximum)
     except ImageSizeError as exc:
         # the image doesn't satisfy the constraint.
         return False, exc.message
     else:
-        # It's ok, reset image position and close method
-        image.file.seek(0)
-        image.close = close_method
+        # XXX: It's ok, reset image position and close method
+        fd.seek(0)
+        fd.close = close_method
         return True, None
 
 
 class ImageForm(forms.Form):
     """Validate that the given image can be resized"""
-    
+
     image = forms.FileField()
     ptype = forms.ChoiceField(
         choices=IMAGE_CHOICES,

--- a/django_images/forms.py
+++ b/django_images/forms.py
@@ -12,7 +12,6 @@ from .settings import IMAGE_FORMATS
 
 
 if sys.version_info > (3, 0):
-    print(sys.version_info)
     PY3 = True
 else:
     PY3 = False
@@ -37,7 +36,11 @@ def validate(image, ptype):
     # but because of the new behavior of str/bytes
     # in python 3 we use the raw fd
     if PY3:
-        fd = image.file.buffer.raw
+        try:
+            fd = image.file.file.raw
+        except AttributeError:
+            # During tests file is backed by a buffer
+            fd = image.file.buffer.raw
     else:
         fd = image
     close_method = fd.close

--- a/django_images/image.py
+++ b/django_images/image.py
@@ -12,12 +12,17 @@ from .settings import IMAGE_FORMATS
 
 
 def store(pil_image, filepath):
+    """Store image on django's `default_storage`"""
     stringio = StringIO()
     pil_image.save(stringio, pil_image.format)
     default_storage.save(filepath, stringio)
 
 
 def save(input_file, filename, ptype):
+    """Save original image `input_file` and generate resized images.
+
+    Return a `Image` instance for the image"""
+
     obj = IMAGE_FORMATS[str(ptype)]
     img = PIL.Image.open(input_file)
     # prepare django Image instance

--- a/django_images/image.py
+++ b/django_images/image.py
@@ -11,53 +11,58 @@ from .models import Image
 from .settings import IMAGE_FORMATS
 
 
-def unique_filepath(folder, filename):
-    filepath = folder + '/' + filename
-    if not default_storage.exists(filepath):
-        return filepath
-    else:
-        while True:
-            filepath = folder + '/' + uuid4().hex
-            filepath += '-' + filename
-            if not default_storage.exists(filepath):
-                return filepath
-
-
-def resize_img(image_file, params):
-    return getattr(
-        resizeimage,
-        'resize_%s' % params['method']
-    )(image_file, params['size'])
-
-
-def save_img(image_file, folder, filename):
-    size = image_file.size
-    filelike = StringIO()
-    image_file.save(filelike, image_file.format)
-    filename = "%s_%sx%s.%s" % (
-        filename,
-        size[0],
-        size[1],
-        image_file.format.lower()
-    )
-    filepath = unique_filepath(folder, filename)
-    default_storage.save(filepath, filelike)
+def store(pil_image, filepath):
+    stringio = StringIO()
+    pil_image.save(stringio, pil_image.format)
+    default_storage.save(filepath, stringio)
 
 
 def save(input_file, filename, ptype):
     obj = IMAGE_FORMATS[str(ptype)]
     img = PIL.Image.open(input_file)
+    # prepare django Image instance
     image = Image()
     image.ptype = ptype
     image.name = filename
     image.ext = img.format.lower()
-    for key, value in obj['sizes'].items():
-        resized_img = resize_img(img, value)
-        setattr(image, key + '_width', resized_img.size[0])
-        setattr(image, key + '_height', resized_img.size[1])
-        save_img(resized_img, obj['folder'], filename)
+
+    folder = obj['folder']
+    # store original image and retrieve uid
+    while True:
+        uid = uuid4().hex
+        filepath = "%s/%s_%sx%s.%s" % (
+            folder,
+            uid,
+            img.size[0],
+            img.size[1],
+            img.format.lower()
+        )
+        # if the original file doesn't exists
+        # it means we have a valid uid
+        if not default_storage.exists(filepath):
+            break
+    image.uid = uid
+    store(img, filepath)
     setattr(image, 'og_width', img.size[0])
     setattr(image, 'og_height', img.size[1])
-    save_img(img, obj['folder'], filename)
+
+    # generate and store other sizes
+    for key, value in obj['sizes'].items():
+        # resize image
+        method = 'resize_%s' % value['method']
+        method = getattr(resizeimage, method)
+        resized = method(img, value['size'], validate=False)
+        # cache width/height
+        setattr(image, key + '_width', resized.size[0])
+        setattr(image, key + '_height', resized.size[1])
+        # store
+        filepath = "%s/%s_%sx%s.%s" % (
+            folder,
+            uid,
+            resized.size[0],
+            resized.size[1],
+            resized.format.lower()
+        )
+        store(resized, filepath)
     image.save()
     return image

--- a/django_images/image.py
+++ b/django_images/image.py
@@ -33,8 +33,13 @@ def save(input_file, filename, ptype):
     """Save original image `input_file` and generate resized images.
 
     Return a `Image` instance for the image"""
+    # workaround difference in byte handling in py3
     if PY3:
-        fd = input_file.file.buffer.raw
+        try:
+            fd = input_file.file.file.raw
+        except AttributeError:
+            # During tests file is backed by a buffer
+            fd = input_file.file.buffer.raw
     else:
         fd = input_file
     obj = IMAGE_FORMATS[str(ptype)]

--- a/django_images/image.py
+++ b/django_images/image.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
+import sys
 import PIL
 from uuid import uuid4
-from cStringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:
+    # StringIO was replaced by io module
+    from io import BytesIO as StringIO
 
 from django.core.files.storage import default_storage
 
@@ -9,6 +14,12 @@ from resizeimage import resizeimage
 
 from .models import Image
 from .settings import IMAGE_FORMATS
+
+
+if sys.version_info > (3, 0):
+    PY3 = True
+else:
+    PY3 = False
 
 
 def store(pil_image, filepath):
@@ -22,9 +33,12 @@ def save(input_file, filename, ptype):
     """Save original image `input_file` and generate resized images.
 
     Return a `Image` instance for the image"""
-
+    if PY3:
+        fd = input_file.file.buffer.raw
+    else:
+        fd = input_file
     obj = IMAGE_FORMATS[str(ptype)]
-    img = PIL.Image.open(input_file)
+    img = PIL.Image.open(fd)
     # prepare django Image instance
     image = Image()
     image.ptype = ptype

--- a/django_images/migrations/0001_initial.py
+++ b/django_images/migrations/0001_initial.py
@@ -14,8 +14,9 @@ class Migration(migrations.Migration):
             name='Image',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('ptype', models.SmallIntegerField(choices=[[1, b'Background image'], [3, b'Picto'], [2, b'Content image'], [4, b'Logo']])),
                 ('name', models.CharField(max_length=255)),
+                ('ptype', models.SmallIntegerField(choices=[[1, b'Background image'], [3, b'Picto'], [2, b'Content image'], [4, b'Logo']])),
+                ('uid', models.CharField(max_length=255)),
                 ('ext', models.CharField(max_length=5)),
                 ('xs_width', models.SmallIntegerField()),
                 ('xs_height', models.SmallIntegerField()),

--- a/django_images/models.py
+++ b/django_images/models.py
@@ -13,8 +13,9 @@ class Image(models.Model):
     """
     manage all images for the application
     """
-    ptype = models.SmallIntegerField(choices=IMAGE_CHOICES)
     name = models.CharField(max_length=255)
+    ptype = models.SmallIntegerField(choices=IMAGE_CHOICES)
+    uid = models.CharField(max_length=255)
     ext = models.CharField(max_length=5)
     xs_width = models.SmallIntegerField()
     xs_height = models.SmallIntegerField()
@@ -41,12 +42,13 @@ class Image(models.Model):
         return url
 
     def filename(self, size):
-        return '%s_%sx%s.%s' % (
-            self.name,
+        filepath = "%s_%sx%s.%s" % (
+            self.uid,
             getattr(self, size + '_width'),
             getattr(self, size + '_height'),
-            self.ext
+            self.ext,
         )
+        return filepath
 
     @property
     def allrelativeurl(self):

--- a/django_images/models.py
+++ b/django_images/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.conf import settings
+from django.core.files.storage import default_storage
 
 from .settings import IMAGE_FORMATS
 
@@ -28,20 +29,32 @@ class Image(models.Model):
     og_width = models.SmallIntegerField()
     og_height = models.SmallIntegerField()
 
+    def delete(self):
+        """Delete generated images from the storage backend"""
+        super(Image, self).delete()
+        for url in map(self.relativeurl, ('xs', 'sm', 'md', 'lg', 'og')):
+            default_storage.delete(url)
+
     def __unicode__(self):
+        """Human readable message to identify the object"""
         return self.name
 
     def relativeurl(self, size):
+        """path relative to the root directory where images are served
+
+        This is by default MEDIA_URL"""
         folder = IMAGE_FORMATS[str(self.ptype)]['folder']
         url = '%s/%s' % (folder, self.filename(size))
         return url
 
     def url(self, size):
+        """Return the full url for a given size"""
         url = settings.MEDIA_URL
         url += self.relativeurl(size)
         return url
 
     def filename(self, size):
+        """Return the filename of an image for a given size"""
         filepath = "%s_%sx%s.%s" % (
             self.uid,
             getattr(self, size + '_width'),
@@ -52,6 +65,7 @@ class Image(models.Model):
 
     @property
     def allrelativeurl(self):
+        """Return all relative urls"""
         arr = []
         arr.append(self.relativeurl('xs'))
         arr.append(self.relativeurl('sm'))
@@ -61,6 +75,7 @@ class Image(models.Model):
         return arr
 
     def image_dict(self, size):
+        """Return dictionary with url, width, height for a given size"""
         return {
             "url": self.url(size),
             "width": getattr(self, size + '_width'),
@@ -69,25 +84,31 @@ class Image(models.Model):
 
     @property
     def xs(self):
+        """Dict for `xs` size."""
         return self.image_dict('xs')
 
     @property
     def sm(self):
+        """Dict for `sm` size."""
         return self.image_dict('sm')
 
     @property
     def md(self):
+        """Dict for `md` size."""
         return self.image_dict('md')
 
     @property
     def lg(self):
+        """Dict for `lg` size."""
         return self.image_dict('lg')
 
     @property
     def og(self):
+        """Dict for `og` size."""
         return self.image_dict('og')
 
     def todict(self):
+        """Serialize the object to a dict."""
         res = {}
         res['xs'] = self.xs
         res['sm'] = self.sm

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,4 @@ setup(
     keywords='image resize bootstrap django',
     packages=['django_images'],
     install_requires=['python-resize-image', 'Django'],
-    test_suite='tests',
 )

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -87,7 +87,8 @@ class TestDjangoImages(TestCase):
         from django_images.models import Image
         image = Image(
             ptype='1',
-            name='test-image-model',
+            name='test image model',
+            uid='42',
             ext='ext',
             xs_width=100,
             xs_height=100,
@@ -102,23 +103,23 @@ class TestDjangoImages(TestCase):
         )
         self.assertEqual(
             image.xs['url'],
-            'http://example.com/media/covers/test-image-model_100x100.ext'
+            'http://example.com/media/covers/42_100x100.ext'
         )
         self.assertEqual(
             image.sm['url'],
-            'http://example.com/media/covers/test-image-model_200x200.ext'
+            'http://example.com/media/covers/42_200x200.ext'
         )
         self.assertEqual(
             image.md['url'],
-            'http://example.com/media/covers/test-image-model_300x300.ext'
+            'http://example.com/media/covers/42_300x300.ext'
         )
         self.assertEqual(
             image.lg['url'],
-            'http://example.com/media/covers/test-image-model_400x400.ext'
+            'http://example.com/media/covers/42_400x400.ext'
         )
         self.assertEqual(
             image.og['url'],
-            'http://example.com/media/covers/test-image-model_1000x1000.ext'
+            'http://example.com/media/covers/42_1000x1000.ext'
         )
 
     def test_fail_to_resize_small_image_in_background_format(self):
@@ -181,4 +182,4 @@ class TestDjangoImages(TestCase):
         # create two times the same image:
         one = create_image()
         two = create_image()
-        self.assertFalse(one.og['url'] != two.og['url'])
+        self.assertTrue(one.og['url'] != two.og['url'])

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,9 @@ setenv=
 [testenv:py27]
 commands=
     python setup.py install
-	coverage run --source "django_images" runtests.py
+    coverage run --source django_images runtests.py
 
 [testenv:py34]
 commands=
-    python setup.py install 
-	coverage run --source "django_images" runtests.py
+    python setup.py install
+    coverage run --source django_images runtests.py


### PR DESCRIPTION
- unique filenames: Another approach is taken to make sure that image files names are unique using `uuid.uuid4` and checking for the existence of the file on the storage. This is done only once, so it still saves a few network calls when the storage is s3.

- Delete images when model is deleted: this is done by overriding `Image.delete` method.

- Build a custom django admin interface for `Image` model ![](https://cloud.githubusercontent.com/assets/7444897/8527542/6d51e69c-240d-11e5-86ba-4f22cb7de549.png)

- Make compatible with python 3
